### PR TITLE
Fix incorrect networkName

### DIFF
--- a/uniswap-v2-polkadot/scripts/deploy.js
+++ b/uniswap-v2-polkadot/scripts/deploy.js
@@ -36,7 +36,7 @@ async function deploy() {
   if (networkName === "localNode") {
     privateKey = process.env.LOCAL_PRIV_KEY;
   }
-  if (networkName === "westendHub") {
+  if (networkName === "passetHub") {
     privateKey = process.env.AH_PRIV_KEY;
   }
   


### PR DESCRIPTION
### Issue 
With private key set in `.env`, deployment to `passetHub` will fail with errors:
```
...
  code: 'INVALID_ARGUMENT',
  argument: 'privateKey',
  value: '[ REDACTED ]',
  shortMessage: 'invalid private key'
...
```

### Possible Fix
The networkName is not configured properly in the deploy script. It should be changed to `passetHub` and the deployment should work as expected.

### Assumption
The issue above happens after following [Uniswap V2 deployment guide](https://docs.polkadot.com/tutorials/smart-contracts/demo-aplications/deploying-uniswap-v2/#deploy-the-contracts).